### PR TITLE
Do not depend on bash

### DIFF
--- a/reproseed.sh
+++ b/reproseed.sh
@@ -9,7 +9,7 @@
 #   ... more!? -- please send a PR
 
 if [ -z "$REPROSEED" ]; then
-    REPROSEED=$(bash -c 'echo $RANDOM')
+    REPROSEED=$(echo $RANDOM)
     _reproseed_src="random"
 else
     _reproseed_src="provided"


### PR DESCRIPTION
The description of reproseed says it's posix compliant, but it's currently depending on bash.

This updates the shell to just use standard shell command substitution, since I don't see why it's using bash in the first place.