### PR TITLE
ENH: provide basic tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 # vim ft=yaml
 before_install:
+  # need NeuroDebian for bats ATM
+  - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+  - travis_retry sudo apt-get update -qq
   - sudo apt-get install shellcheck bats
 # TODO? May be matrix it via sh, dash, bash, and even zsh?
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 # vim ft=yaml
 before_install:
-  - sudo apt-get install shellcheck
+  - sudo apt-get install shellcheck bats
 # TODO? May be matrix it via sh, dash, bash, and even zsh?
 install:
 script:
   - shellcheck -s sh reproseed.sh
+  - bats tests/test_*.sh

--- a/tests/test_basic.sh
+++ b/tests/test_basic.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# export PATH=$(dirname $0/..):$PATH
+REPROSEED_CMD="../reproseed.sh"
+
+testSource()
+{
+	. $REPROSEED_CMD
+	assertEquals "$AFNI_RANDOM_SEEDVAL" "$REPROSEED"
+	assertEquals "$MVPA_SEED" "$REPROSEED"
+}
+
+testSourceOutput() {
+	out=`. $REPROSEED_CMD`
+	#assertTrue "echo $out | grep -q '(random)'"
+	assertContains '(random)' "$out"
+}
+
+testSourceSeeded()
+{
+	REPROSEED=1 . $REPROSEED_CMD
+	assertEquals "$REPROSEED" 1
+	assertEquals "$AFNI_RANDOM_SEEDVAL" "$REPROSEED"
+	assertEquals "$MVPA_SEED" "$REPROSEED"
+}
+
+. shunit2

--- a/tests/test_basic.sh
+++ b/tests/test_basic.sh
@@ -1,27 +1,28 @@
-#!/bin/sh
+#!/usr/bin/env bats
 
 # export PATH=$(dirname $0/..):$PATH
 REPROSEED_CMD="../reproseed.sh"
 
-testSource()
-{
+common_checks() {
+	# Common checks to see if all seeds in the environment are equal
+	# to the desired value
+	[ "$REPROSEED" = "$1" ]
+	[ "$AFNI_RANDOM_SEEDVAL" = "$REPROSEED" ]
+	[ "$MVPA_SEED" = "$REPROSEED" ]
+
+}
+
+@test "source basic functionality test" {
 	. $REPROSEED_CMD
-	assertEquals "$AFNI_RANDOM_SEEDVAL" "$REPROSEED"
-	assertEquals "$MVPA_SEED" "$REPROSEED"
+	common_checks "$REPROSEED"
 }
 
-testSourceOutput() {
-	out=`. $REPROSEED_CMD`
-	#assertTrue "echo $out | grep -q '(random)'"
-	assertContains '(random)' "$out"
+@test "source check output" {
+ 	out=`. $REPROSEED_CMD`
+ 	echo $out | grep -q '(random)'
 }
 
-testSourceSeeded()
-{
-	REPROSEED=1 . $REPROSEED_CMD
-	assertEquals "$REPROSEED" 1
-	assertEquals "$AFNI_RANDOM_SEEDVAL" "$REPROSEED"
-	assertEquals "$MVPA_SEED" "$REPROSEED"
+@test "seed and source" {
+ 	REPROSEED=1 . $REPROSEED_CMD
+	eval common_checks 1
 }
-
-. shunit2

--- a/tests/test_basic.sh
+++ b/tests/test_basic.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 # export PATH=$(dirname $0/..):$PATH
-REPROSEED_CMD="../reproseed.sh"
+REPROSEED_CMD="./reproseed.sh"
 
 common_checks() {
 	# Common checks to see if all seeds in the environment are equal
@@ -25,4 +25,16 @@ common_checks() {
 @test "seed and source" {
  	REPROSEED=1 . $REPROSEED_CMD
 	eval common_checks 1
+}
+
+@test "execute" {
+ 	out=$($REPROSEED_CMD export | grep SEED)
+	echo "$out" | grep -q '(random)'
+	echo "$out" | grep -q 'AFNI_RANDOM_SEEDVAL'
+}
+
+@test "seed execute" {
+ 	out=$(REPROSEED=1 $REPROSEED_CMD export | grep SEED)
+	echo "$out" | grep -q 'REPROSEED=1 (provided)'
+	echo "$out" | grep -q "AFNI_RANDOM_SEEDVAL='1'"
 }


### PR DESCRIPTION
For now at least via bats, although bats is bash specific so we would not be able to test for POSIX compliant execution I guess unless explicitly calling out to `sh`